### PR TITLE
Add colors and scores for finished matches

### DIFF
--- a/matchups.html
+++ b/matchups.html
@@ -36,6 +36,18 @@
       margin: 0 auto;
     }
 
+    .winner {
+      background: #e6ffe6;
+    }
+
+    .loser {
+      background: #ffecec;
+    }
+
+    .draw {
+      background: #e9f0ff;
+    }
+
       .match {
         background: white;
         padding: 20px;
@@ -83,6 +95,14 @@
     .result {
       font-size: 0.9rem;
       color: #666;
+    }
+
+    .match-result {
+      font-size: 0.9rem;
+      width: 100%;
+      text-align: center;
+      font-weight: bold;
+      margin-top: 5px;
     }
 
     .vs {
@@ -138,11 +158,11 @@
 
     function getWinner(match) {
       const winningPlayer = match.winning_player;
-      if (!winningPlayer) return "TBD";
+      if (!winningPlayer) return null;
       const [p1, p2] = match.player_match_relationships;
-      if (winningPlayer === p1.player.id) return `${p1.user_event_status.best_identifier} won`;
-      if (winningPlayer === p2.player.id) return `${p2.user_event_status.best_identifier} won`;
-      return "TBD";
+      if (winningPlayer === p1.player.id) return p1.user_event_status.best_identifier;
+      if (winningPlayer === p2.player.id) return p2.user_event_status.best_identifier;
+      return null;
     }
 
     function renderMatches(matches) {
@@ -164,28 +184,33 @@
             </div>
           `;
         }
-          const result1 = getWinner(match);
+          const winner = getWinner(match);
+          const resultText = winner ? `${winner} won` : (match.games_won_by_winner != null ? 'Draw' : 'TBD');
+          const score = (match.games_won_by_winner != null && match.games_won_by_loser != null)
+            ? `${match.games_won_by_winner}-${match.games_won_by_loser}`
+            : '';
+          const matchClass = !winner && score ? 'draw' : '';
+          const p1Class = winner && winner === p1.user_event_status.best_identifier ? 'winner' : (winner ? 'loser' : matchClass);
+          const p2Class = winner && winner === p2.user_event_status.best_identifier ? 'winner' : (winner ? 'loser' : matchClass);
           return `
-            <div class="match" data-names="${p1?.user_event_status.best_identifier.toLowerCase()} ${p2?.user_event_status.best_identifier.toLowerCase()}">
+            <div class="match ${matchClass}" data-names="${p1?.user_event_status.best_identifier.toLowerCase()} ${p2?.user_event_status.best_identifier.toLowerCase()}">
               <div class="table-number">Table ${match.table_number ?? '-'}</div>
-              <div class="player">
+              <div class="player ${p1Class}">
                 <img src="${p1?.player.game_user_profile_picture_url}" class="avatar" alt="${p1?.player.best_identifier}" />
                 <div class="info">
                   <span class="name">${p1?.user_event_status.best_identifier}</span>
                 </div>
-            </div>
-            <div class="vs">vs</div>
-            <div class="player">
-              <img src="${p2?.player.game_user_profile_picture_url}" class="avatar" alt="${p2?.player.best_identifier}" />
-              <div class="info">
-                <span class="name">${p2?.user_event_status.best_identifier}</span>
               </div>
-              <div class="result">
-                ${result1}
+              <div class="vs">vs</div>
+              <div class="player ${p2Class}">
+                <img src="${p2?.player.game_user_profile_picture_url}" class="avatar" alt="${p2?.player.best_identifier}" />
+                <div class="info">
+                  <span class="name">${p2?.user_event_status.best_identifier}</span>
+                </div>
               </div>
+              <div class="match-result">${resultText}${score ? ` (${score})` : ''}</div>
             </div>
-          </div>
-        `;
+          `;
       }).join('');
     }
 


### PR DESCRIPTION
## Summary
- style winners, losers and draws
- show final scores and color players when matches finish

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884cbf21a208329b7c9e07083b01ec8