### PR TITLE
Add round selection with caching

### DIFF
--- a/matchups.html
+++ b/matchups.html
@@ -131,25 +131,58 @@
 <body>
 
   <h1>Tournament Matchups</h1>
+  <select id="roundSelect"></select>
   <input type="text" id="search" placeholder="Search player name...">
 
   <div id="matches" class="matches"></div>
 
   <script>
     const proxy = "https://corsproxy.io/?";
-    const endpoint = "https://api.ravensburgerplay.com/api/v2/tournament-rounds/28411/matches/paginated/?page=1&page_size=100&avoid_cache=true";
+    const eventEndpoint = "https://api.ravensburgerplay.com/api/v2/events/166598/";
     const matchesContainer = document.getElementById("matches");
     const searchInput = document.getElementById("search");
+    const roundSelect = document.getElementById("roundSelect");
     let allMatches = [];
 
-    async function fetchMatchups() {
-      try {
-        matchesContainer.innerHTML = "<p>Loading matchups.</p>";
+    async function loadRounds() {
+      const cached = localStorage.getItem('eventRounds');
+      if (cached) return JSON.parse(cached);
+      const res = await fetch(proxy + encodeURIComponent(eventEndpoint));
+      const data = await res.json();
+      const rounds = data.tournament_rounds || data.rounds || [];
+      localStorage.setItem('eventRounds', JSON.stringify(rounds));
+      return rounds;
+    }
 
-        const res = await fetch(proxy + encodeURIComponent(endpoint));
+    function populateRoundSelect(rounds) {
+      roundSelect.innerHTML = rounds.map(r => {
+        const id = r.id || r.round_id || r.tournament_round;
+        const label = r.name || `Round ${r.round_number ?? r.number ?? id}`;
+        return `<option value="${id}">${label}</option>`;
+      }).join('');
+    }
+
+    async function fetchMatchups(roundId) {
+      try {
+        const cacheKey = `round_${roundId}_matches`;
+        const cached = localStorage.getItem(cacheKey);
+        if (cached) {
+          allMatches = JSON.parse(cached);
+          renderMatches(allMatches);
+          return;
+        }
+
+        matchesContainer.innerHTML = "<p>Loading matchups.</p>";
+        const url = `https://api.ravensburgerplay.com/api/v2/tournament-rounds/${roundId}/matches/paginated/?page=1&page_size=100&avoid_cache=true`;
+        const res = await fetch(proxy + encodeURIComponent(url));
         const data = await res.json();
         allMatches = data.results;
         renderMatches(allMatches);
+        const finished = allMatches.every(m => m.winning_player || m.games_won_by_winner !== null);
+        if (finished) {
+          localStorage.setItem(cacheKey, JSON.stringify(allMatches));
+          localStorage.setItem(`round_${roundId}_over`, 'true');
+        }
       } catch (err) {
         console.error("Error fetching matchups:", err);
         matchesContainer.innerHTML = "<p>Error loading matchups.</p>";
@@ -225,7 +258,14 @@
       renderMatches(filtered);
     });
 
-    fetchMatchups();
+    roundSelect.addEventListener('change', e => {
+      fetchMatchups(e.target.value);
+    });
+
+    loadRounds().then(rs => {
+      populateRoundSelect(rs);
+      if (roundSelect.value) fetchMatchups(roundSelect.value);
+    });
   </script>
 </body>
 

--- a/matchups.html
+++ b/matchups.html
@@ -142,6 +142,7 @@
     const matchesContainer = document.getElementById("matches");
     const searchInput = document.getElementById("search");
     const roundSelect = document.getElementById("roundSelect");
+    const selectedRoundKey = 'selectedRound';
     let allMatches = [];
 
     async function loadRounds() {
@@ -149,7 +150,8 @@
       if (cached) return JSON.parse(cached);
       const res = await fetch(proxy + encodeURIComponent(eventEndpoint));
       const data = await res.json();
-      const rounds = data.tournament_rounds || data.rounds || [];
+      let rounds = data.tournament_rounds || data.rounds || [];
+      if (rounds.results) rounds = rounds.results;
       localStorage.setItem('eventRounds', JSON.stringify(rounds));
       return rounds;
     }
@@ -160,10 +162,13 @@
         const label = r.name || `Round ${r.round_number ?? r.number ?? id}`;
         return `<option value="${id}">${label}</option>`;
       }).join('');
+      const stored = localStorage.getItem(selectedRoundKey);
+      if (stored) roundSelect.value = stored;
     }
 
     async function fetchMatchups(roundId) {
       try {
+        if (!roundId) return;
         const cacheKey = `round_${roundId}_matches`;
         const cached = localStorage.getItem(cacheKey);
         if (cached) {
@@ -178,7 +183,11 @@
         const data = await res.json();
         allMatches = data.results;
         renderMatches(allMatches);
-        const finished = allMatches.every(m => m.winning_player || m.games_won_by_winner !== null);
+        const finished = allMatches.every(m =>
+          m.winning_player &&
+          m.games_won_by_winner != null &&
+          m.games_won_by_loser != null
+        );
         if (finished) {
           localStorage.setItem(cacheKey, JSON.stringify(allMatches));
           localStorage.setItem(`round_${roundId}_over`, 'true');
@@ -259,7 +268,9 @@
     });
 
     roundSelect.addEventListener('change', e => {
-      fetchMatchups(e.target.value);
+      const val = e.target.value;
+      localStorage.setItem(selectedRoundKey, val);
+      fetchMatchups(val);
     });
 
     loadRounds().then(rs => {

--- a/standings.html
+++ b/standings.html
@@ -88,6 +88,7 @@
     const standingsContainer = document.getElementById('standings');
     const searchInput = document.getElementById('search');
     const roundSelect = document.getElementById('roundSelect');
+    const selectedRoundKey = 'selectedRound';
     let players = [];
 
     async function loadRounds() {
@@ -95,7 +96,8 @@
       if (cached) return JSON.parse(cached);
       const res = await fetch(proxy + encodeURIComponent(eventEndpoint));
       const data = await res.json();
-      const rounds = data.tournament_rounds || data.rounds || [];
+      let rounds = data.tournament_rounds || data.rounds || [];
+      if (rounds.results) rounds = rounds.results;
       localStorage.setItem('eventRounds', JSON.stringify(rounds));
       return rounds;
     }
@@ -106,10 +108,13 @@
         const label = r.name || `Round ${r.round_number ?? r.number ?? id}`;
         return `<option value="${id}">${label}</option>`;
       }).join('');
+      const stored = localStorage.getItem(selectedRoundKey);
+      if (stored) roundSelect.value = stored;
     }
 
     async function fetchStandings(roundId) {
       try {
+        if (!roundId) return;
         const cacheKey = `round_${roundId}_standings`;
         const cached = localStorage.getItem(cacheKey);
         if (cached) {
@@ -158,7 +163,9 @@
     });
 
     roundSelect.addEventListener('change', e => {
-      fetchStandings(e.target.value);
+      const val = e.target.value;
+      localStorage.setItem(selectedRoundKey, val);
+      fetchStandings(val);
     });
 
     loadRounds().then(rs => {

--- a/standings.html
+++ b/standings.html
@@ -77,27 +77,56 @@
 <body>
 
   <h1>Tournament Standings</h1>
+  <select id="roundSelect"></select>
   <input type="text" id="search" placeholder="Search player name...">
 
   <div id="standings" class="grid"></div>
 
   <script>
     const proxy = "https://corsproxy.io/?";
-    //https://api.ravensburgerplay.com/api/v2/tournament-rounds/28411/standings/paginated/?page=1&page_size=10&avoid_cache=true
-    //https://api.ravensburgerplay.com/api/v2/tournament-rounds/28409/standings/paginated/?page=1&page_size=400&avoid_cache=true
-    const endpoint = proxy + encodeURIComponent("https://api.ravensburgerplay.com/api/v2/tournament-rounds/28411/standings/paginated/?page=1&page_size=400&avoid_cache=true");
+    const eventEndpoint = "https://api.ravensburgerplay.com/api/v2/events/166598/";
     const standingsContainer = document.getElementById('standings');
     const searchInput = document.getElementById('search');
+    const roundSelect = document.getElementById('roundSelect');
     let players = [];
 
-    async function fetchStandings() {
-      try {
-        standingsContainer.innerHTML = "<p>Loading standings...</p>";
+    async function loadRounds() {
+      const cached = localStorage.getItem('eventRounds');
+      if (cached) return JSON.parse(cached);
+      const res = await fetch(proxy + encodeURIComponent(eventEndpoint));
+      const data = await res.json();
+      const rounds = data.tournament_rounds || data.rounds || [];
+      localStorage.setItem('eventRounds', JSON.stringify(rounds));
+      return rounds;
+    }
 
-        const res = await fetch(endpoint);
+    function populateRoundSelect(rounds) {
+      roundSelect.innerHTML = rounds.map(r => {
+        const id = r.id || r.round_id || r.tournament_round;
+        const label = r.name || `Round ${r.round_number ?? r.number ?? id}`;
+        return `<option value="${id}">${label}</option>`;
+      }).join('');
+    }
+
+    async function fetchStandings(roundId) {
+      try {
+        const cacheKey = `round_${roundId}_standings`;
+        const cached = localStorage.getItem(cacheKey);
+        if (cached) {
+          players = JSON.parse(cached);
+          renderPlayers(players);
+          return;
+        }
+
+        standingsContainer.innerHTML = "<p>Loading standings...</p>";
+        const url = `https://api.ravensburgerplay.com/api/v2/tournament-rounds/${roundId}/standings/paginated/?page=1&page_size=400&avoid_cache=true`;
+        const res = await fetch(proxy + encodeURIComponent(url));
         const data = await res.json();
         players = data.results;
         renderPlayers(players);
+        if (localStorage.getItem(`round_${roundId}_over`) === 'true') {
+          localStorage.setItem(cacheKey, JSON.stringify(players));
+        }
       } catch (err) {
         standingsContainer.innerHTML = '<p>Error loading data.</p>';
       }
@@ -128,7 +157,14 @@
       renderPlayers(filtered);
     });
 
-    fetchStandings();
+    roundSelect.addEventListener('change', e => {
+      fetchStandings(e.target.value);
+    });
+
+    loadRounds().then(rs => {
+      populateRoundSelect(rs);
+      if (roundSelect.value) fetchStandings(roundSelect.value);
+    });
   </script>
 </body>
 


### PR DESCRIPTION
## Summary
- fetch event rounds once and cache in localStorage
- add round selector to `matchups` and `standings`
- cache finished round data to avoid extra API calls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884d03f65008329b2670b7b51a1fda1